### PR TITLE
Expose `ChangeLanguage` as a public event

### DIFF
--- a/API-REFERENCE.md
+++ b/API-REFERENCE.md
@@ -43,6 +43,17 @@ The language code that was stored by this method will be read at launching the B
 
 If you want to change this storing behavior, you can configure it at service registration (see also: `AddI18nText(...)` extension method.).
 
+### `ChangeLanguage` event
+
+#### Syntax
+
+```csharp
+public event EventHandler<I18nTextChangeLanguageEventArgs> ChangeLanguage;
+```
+
+#### Description
+This event will be invoked after the language is changed.  It is invoked after the language has been changed, but before the component state has changed.
+
 ### `GetTextTableAsync()` method
 
 #### Syntax

--- a/Tests/Components/Shared/MainLayout.razor
+++ b/Tests/Components/Shared/MainLayout.razor
@@ -48,6 +48,10 @@
         }
 
         Text = await I18nText.GetTextTableAsync<Text>(this);
+        I18nText.ChangeLanguage += (s, a) =>
+        {
+            Console.WriteLine($"Language Changed: {a.LanguageCode}");
+        };
     }
 
     private async Task OnChangeCurrentLang(ChangeEventArgs args)

--- a/Tests/Components/Shared/NavMenu.razor
+++ b/Tests/Components/Shared/NavMenu.razor
@@ -1,7 +1,7 @@
 ﻿@inject Toolbelt.Blazor.I18nText.I18nText I18nText
 
 <div class="top-row pl-4 navbar navbar-dark">
-    <a class="navbar-brand" href="">@Text.SiteName</a>
+    <a class="navbar-brand" href="/">@Text.SiteName</a>
     <button class="navbar-toggler" @onclick="ToggleNavMenu">
         <span class="navbar-toggler-icon"></span>
     </button>

--- a/Toolbelt.Blazor.I18nText/I18nText.cs
+++ b/Toolbelt.Blazor.I18nText/I18nText.cs
@@ -24,6 +24,8 @@ namespace Toolbelt.Blazor.I18nText
 
         private readonly Guid ScopeId = Guid.NewGuid();
 
+        public event EventHandler<I18nTextChangeLanguageEventArgs> ChangeLanguage;
+
         internal I18nText(IServiceProvider serviceProvider, I18nTextOptions options)
         {
             this.ServiceProvider = serviceProvider;
@@ -55,6 +57,7 @@ namespace Toolbelt.Blazor.I18nText
 
             this._CurrentLanguage = langCode;
             await this.I18nTextRepository.ChangeLanguageAsync(this.ScopeId, this._CurrentLanguage);
+            this.ChangeLanguage?.Invoke(this, new I18nTextChangeLanguageEventArgs(langCode));
 
             this.Components.InvokeStateHasChanged();
         }


### PR DESCRIPTION
In `I18nText`, `ChangeLanguage` is now a public event to notify when `SetCurrentLanguageAsync` is called.

References #35 

- [x] Added API
- [x] Update Tests project
- [x] Updated `API-REFERENCE.md`