### PR TITLE
adding option of pulling properties by name via reflection

### DIFF
--- a/Toolbelt.Blazor.I18nText.Compiler.Shared/I18nTextCompiler.cs
+++ b/Toolbelt.Blazor.I18nText.Compiler.Shared/I18nTextCompiler.cs
@@ -105,6 +105,17 @@ namespace Toolbelt.Blazor.I18nText
                 typeCode.Add("");
                 typeCode.Add("        public string this[string key] => global::Toolbelt.Blazor.I18nText.I18nTextExtensions.GetFieldValue(this, key);");
                 typeCode.Add("");
+                typeCode.Add("        public string GetValueByName(string propertyName)");
+                typeCode.Add("        {");
+                typeCode.Add("            var type = this.GetType();");
+                typeCode.Add("            var typeName = type.Name;");
+                typeCode.Add("            var value = type.GetProperty(propertyName)?.GetValue(this, null);");
+                typeCode.Add("");
+                typeCode.Add("            if (value == null)");
+                typeCode.Add("                throw new ArgumentException($\"Provided property {propertyName} for object {typeName} was not found on the compiled object.\");");
+                typeCode.Add("            ");
+                typeCode.Add("            return value?.ToString()!;");
+                typeCode.Add("        }");
                 var is1stLine = true;
                 foreach (var textKey in comilerItem.Type.Value.TextKeys)
                 {


### PR DESCRIPTION
I have a use case where I would like to use the i18n features on a product page and have specific product translations in the json document. 

I am of the mind that a product with an ID of 1234 could have configurations in the translation document as follows
```
{
   'product1234name' : 'my happy new product',
   'product1234description' : 'product description english...'
}
```

What I would like to be able to do is as follows:

```
<h1>@Products.GetValueByName($"product{product.Id}name")</h1>
```

This way products can be defined in the database, but translations could be performed outside of doing database changes. So long as the key is unchanged, compile time changes would not be required as they are loaded from the json doc.

Thoughts?
